### PR TITLE
add config for the name column field length of migration table

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -28,7 +28,8 @@ function Adapter (params) {
 
     this.config = {
         migrationFile: "migrationTemplate.js",
-        migrationTable: "_migrations"
+        migrationTable: "_migrations",
+        nameFieldLength: 50,
     };
 
     if (this.params.eastMysql && this.params.eastMysql.migrationTable) {
@@ -43,6 +44,9 @@ function Adapter (params) {
         this.config.resetExecution = true;
     }
 
+    if (this.params.eastMysql && this.params.eastMysql.nameFieldLength) {
+        this.config.nameFieldLength = this.params.eastMysql.nameFieldLength;
+    }
 }
 
 
@@ -125,7 +129,7 @@ Adapter.prototype.connect = function (cb) {
      */
     tasks.push(function (callback) {
 
-        var sql = "CREATE TABLE IF NOT EXISTS " + self.config.migrationTable + " (`name` VARCHAR(50) NOT NULL, PRIMARY KEY (`name`))";
+        var sql = "CREATE TABLE IF NOT EXISTS " + self.config.migrationTable + " (`name` VARCHAR(" + self.config.nameFieldLength + ") NOT NULL, PRIMARY KEY (`name`))";
 
         self.db.query(sql, function (err) {
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "chai": "~2.2.0",
     "grunt": "~0.4.5",
+    "grunt-cli": "^1.3.2",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-copy": "~0.8.0",
     "grunt-contrib-jshint": "~0.11.1",

--- a/test/unit/adapter.test.js
+++ b/test/unit/adapter.test.js
@@ -75,7 +75,8 @@ describe("adapter test", function () {
             expect(obj.config).to.be.an("object")
                 .to.be.eql({
                 migrationFile: "migrationTemplate.js",
-                migrationTable: "_migrations"
+                migrationTable: "_migrations",
+                nameFieldLength: 50
             });
 
         });
@@ -86,14 +87,16 @@ describe("adapter test", function () {
                 url: "some url",
                 eastMysql: {
                     migrationFile: 'overrideMigrateTemplate.js',
-                    migrationTable: '_override'
+                    migrationTable: '_override',
+                    nameFieldLength: 255
                 }
             });
 
             expect(obj.config).to.be.an("object")
                 .to.be.eql({
                 migrationFile: "overrideMigrateTemplate.js",
-                migrationTable: "_override"
+                migrationTable: "_override",
+                nameFieldLength: 255
             });
 
         });


### PR DESCRIPTION
We want to be able to use longer more descriptive names for migration files. This pr adds a param config to override the default name length (50). 